### PR TITLE
Allow autoconfig of filter via url-patterns property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.1
+- Allow autoconfig of filter via url-patterns property (fixes [#3](https://github.com/lukashinsch/spring-boot-actuator-user-agent-metrics/issues/3))
+
+## 0.1.0
+- First release

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'propdeps'
 apply plugin: 'jacoco'
 apply plugin: 'com.github.kt3k.coveralls'
 
-version = '0.1.0'
+version = '0.1.1'
 
 jar {
     baseName = 'spring-boot-actuator-user-agent-metrics'

--- a/src/main/java/eu/hinsch/spring/boot/actuator/useragent/UserAgentMetricFilterAutoConfiguration.java
+++ b/src/main/java/eu/hinsch/spring/boot/actuator/useragent/UserAgentMetricFilterAutoConfiguration.java
@@ -1,5 +1,8 @@
 package eu.hinsch.spring.boot.actuator.useragent;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.embedded.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
@@ -9,4 +12,14 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @ComponentScan(basePackageClasses = UserAgentMetricFilterAutoConfiguration.class)
 public class UserAgentMetricFilterAutoConfiguration {
+
+    @ConditionalOnProperty("user-agent-metric.url-patterns")
+    @Bean
+    public FilterRegistrationBean userAgentMetricFilterRegistrationBean(final UserAgentMetricFilter filter,
+                                                                        UserAgentMetricFilterConfiguration configuration) {
+        final FilterRegistrationBean bean = new FilterRegistrationBean();
+        bean.setFilter(filter);
+        bean.setUrlPatterns(configuration.getUrlPatterns());
+        return bean;
+    }
 }

--- a/src/main/java/eu/hinsch/spring/boot/actuator/useragent/UserAgentMetricFilterConfiguration.java
+++ b/src/main/java/eu/hinsch/spring/boot/actuator/useragent/UserAgentMetricFilterConfiguration.java
@@ -13,6 +13,7 @@ import java.util.List;
 @ConfigurationProperties("user-agent-metric")
 public class UserAgentMetricFilterConfiguration {
     private List<String> keys = new ArrayList<>();
+    private List<String> urlPatterns = new ArrayList<>();
 
     public List<String> getKeys() {
         return keys;
@@ -20,5 +21,13 @@ public class UserAgentMetricFilterConfiguration {
 
     public void setKeys(List<String> keys) {
         this.keys = keys;
+    }
+
+    public List<String> getUrlPatterns() {
+        return urlPatterns;
+    }
+
+    public void setUrlPatterns(List<String> urlPatterns) {
+        this.urlPatterns = urlPatterns;
     }
 }

--- a/src/test/java/eu/hinsch/spring/boot/actuator/useragent/SpringBootActuatorUserAgentMetricsTestApplication.java
+++ b/src/test/java/eu/hinsch/spring/boot/actuator/useragent/SpringBootActuatorUserAgentMetricsTestApplication.java
@@ -2,8 +2,6 @@ package eu.hinsch.spring.boot.actuator.useragent;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.context.embedded.FilterRegistrationBean;
-import org.springframework.context.annotation.Bean;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -11,14 +9,6 @@ import org.springframework.web.bind.annotation.RestController;
 @SpringBootApplication
 @RestController
 public class SpringBootActuatorUserAgentMetricsTestApplication {
-
-    @Bean
-    public FilterRegistrationBean filter(UserAgentMetricFilter filter) {
-        FilterRegistrationBean bean = new FilterRegistrationBean();
-        bean.setFilter(filter);
-        bean.addUrlPatterns("/test");
-        return bean;
-    }
 
     @RequestMapping("/test")
     @ResponseBody

--- a/src/test/java/eu/hinsch/spring/boot/actuator/useragenttest/UserAgentFilterIntegrationTest.java
+++ b/src/test/java/eu/hinsch/spring/boot/actuator/useragenttest/UserAgentFilterIntegrationTest.java
@@ -1,5 +1,6 @@
-package eu.hinsch.spring.boot.actuator.useragent;
+package eu.hinsch.spring.boot.actuator.useragenttest;
 
+import eu.hinsch.spring.boot.actuator.useragent.UserAgentMetricFilter;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -4,3 +4,7 @@ user-agent-metric:
     - '#this.name + "." + #this.versionNumber.major'
     - '#this.operatingSystem.name'
     - '@currentRequest.remoteAddr'
+  url-patterns: /test
+# alternatively:
+#    - /test
+#    - /test2


### PR DESCRIPTION
- fixes [#3](https://github.com/lukashinsch/spring-boot-actuator-user-agent-metrics/issues/3)
